### PR TITLE
Update links for FA24

### DIFF
--- a/index.html
+++ b/index.html
@@ -363,7 +363,7 @@
                            href="https://www.olin.edu/academics-registrars-office/independent-study-research"
                            target="_blank" rel="noopener">Independent Study/Research</a>
                         <a class="list-group-item list-group-item-action waves-effect"
-                           href="https://forms.office.com/Pages/ResponsePage.aspx?id=0FRi_5BGikakrYKKzju2aID6k8mZnYtIp5okwJSJyXFUNzFDSzdLUFEwNzlaNjMySTRERDEzSTVXOCQlQCN0PWcu"
+                           href="https://forms.office.com/Pages/ResponsePage.aspx?id=0FRi_5BGikakrYKKzju2aPRWpVegiWFAnUNASBP9JXhUODdGTU9WV05QOFlBQVRGTUhVQlBCM0VZSyQlQCN0PWcu"
                            target="_blank" rel="noopener">Passionate Pursuit Proposal</a>
                         <!-- <a class="list-group-item list-group-item-action waves-effect"
                            href="http://www.olin.edu/sites/default/files/reg_passionate_pursuit_reimbursement_form.pdf"

--- a/index.html
+++ b/index.html
@@ -886,18 +886,6 @@
     </div>
 
 
-      <!-- One Card -->
-      <a class="tile col-xl-3 col-lg-3 col-md-4 col-sm-6 col-12 mb-4" id="onecard"
-      href="https://olin-sp.transactcampus.com/eAccounts/AccountSummary.aspx" target="_blank" rel="noopener">
-       <div class="tile-wrapper hoverable flex-center img-fluid z-depth-1"
-            style="background: url('images/onecard.jpg') center; background-size: cover">
-           <div class="tile-title flex-center">
-               <h2>OneCard</h2>
-           </div>
-       </div>
-   </a>
-
-
     <!-- Room Scheulding (replaces Ad Astra) -->
     <a class="tile col-xl-3 col-lg-3 col-md-4 col-sm-6 col-12 mb-4" id="adastra"
         href="https://wikis.olin.edu/it/doku.php?id=room_schedule_info" target="_blank" rel="noopener">

--- a/index.html
+++ b/index.html
@@ -741,7 +741,7 @@
                     </button>
                 </div>
                 <div class="modal-body">
-                    FrankCares: (833) 434-1217 </br>
+                    UWill Crisis Line: 833-646-1526 </br>
 
                     <div class="list-group">
                         <a class="list-group-item list-group-item-action waves-effect"

--- a/index.html
+++ b/index.html
@@ -825,6 +825,14 @@
                             href="https://calendly.com/patrickclarkson"
                             target="_blank" rel="noopener">Schedule An Appointment with Patrick
                         </a>
+                        <a class="list-group-item list-group-item-action waves-effect"
+                            href="https://forms.office.com/r/YUaEXYvmbj"
+                            target="_blank" rel="noopener">Overnight Guest Form
+                        </a>
+                        <a class="list-group-item list-group-item-action waves-effect"
+                            href="https://forms.office.com/r/SFFxpZeBuY"
+                            target="_blank" rel="noopener">Pet/Fish Form
+                        </a>
                         </a>
                         
                     </div>

--- a/index.html
+++ b/index.html
@@ -390,6 +390,9 @@
                         <a class="list-group-item list-group-item-action waves-effect"
                            href="https://forms.office.com/Pages/ResponsePage.aspx?id=0FRi_5BGikakrYKKzju2aIjnR6ujpyVFhWFfU0zYcv9UN1dEWTRPNERTQ01EMkhHSEtBSjNZMzM1Vi4u&wdLOR=cC55AC806-BB94-4EF1-92AA-B4384A0E77E5"
                            target="_blank" rel="noopener">Directory Name & Pronoun Change Form</a>
+                        <a class="list-group-item list-group-item-action waves-effect"
+                           href="https://forms.office.com/r/JBNNBRbKac"
+                           target="_blank" rel="noopener">ARC Request Form</a>
 
                     </div>
                 </div>


### PR DESCRIPTION
- Update various StAR links and forms for the current year
- Remove the OneCard section, as the website it links to has been deprecated (it is no longer possible to add money to your OneCard, and this was the only purpose of the site)
- Replace the previous FrankCares mental health crisis line with the new UWill support line.
- Add link to the ARC request form (currently links to the SP24 form, but the same form link will be updated/reused for FA24)